### PR TITLE
Group packages by type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ mkdocs: zf-mkdoc-theme zf-component-list.json docs/book/index.html
 	- sed --in-place -r -e 's/\"\.\./"/g' 404.html
 	- sed --in-place -r -e 's/href\=\"\"/href="\/"/g' 404.html
 	- sed --in-place -r -e 's/<a [^>]+>Not Found<\/a>//g' 404.html
-	- sed --in-place -r -e 's/<a [^>]+>404<\/a>//g' index.html
+	- sed --in-place -r -e 's/<a [^>]+>404\/?<\/a>//g' index.html
 	- rm index.html.dist
 
 build: ready mkdocs clean

--- a/docs/book/css/site.css
+++ b/docs/book/css/site.css
@@ -8,18 +8,23 @@
   border-bottom: 0;
 }
 
-.components {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: flex-start;
-  align-content: flex-start;
+@media screen and (min-width: 768px) {
+  .components {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-start;
+    align-content: flex-start;
+  }
+
+  .component {
+    flex-basis: 48%;
+  }
 }
 
 .component {
   min-height: 200px;
-  flex-basis: 48%;
   border: 1px solid #CCCCCC;
   border-radius: 10px;
   margin-bottom: 1em;

--- a/docs/book/index.html.dist
+++ b/docs/book/index.html.dist
@@ -1,14 +1,6 @@
 <div class="jumbotron">
-  <h1>Zend Framework Components</h1>
+  <h1>Zend Framework Documentation</h1>
 
-  <p>Documentation for the ZF components</p>
-</div>
-
-<div class="panel panel-info">
-  <div class="panel-heading">Tutorials</div>
-
-  <div class="panel-body">
-    Learn Zend Framework and Expressive in-depth via our <a href="/tutorials">tutorials</a>.
-  </div>
+  <p>Documentation for the MVC Framework, Expressive, and all Components</p>
 </div>
 


### PR DESCRIPTION
Recently, I added a "group" element to all packages in the `zf-component-list.json` file, allowing us to group under several main topics.

This patch updates the script that prepares the home page to create these groups.

Additionally, it makes the following fixes:

- Updates the `sed` that fines the `404` link in the `Makefile` to allow an optional `/` character following the text (randomly observed this).
- Updates the CSS to only display two columns of packages when we have a width of at least 768px.